### PR TITLE
hermit: disable signals and process when using hermit

### DIFF
--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -316,6 +316,7 @@ macro_rules! cfg_process {
             #[cfg_attr(docsrs, doc(cfg(feature = "process")))]
             #[cfg(not(loom))]
             #[cfg(not(target_os = "wasi"))]
+            #[cfg(not(target_os = "hermit"))]
             $item
         )*
     }
@@ -345,6 +346,7 @@ macro_rules! cfg_signal {
             #[cfg_attr(docsrs, doc(cfg(feature = "signal")))]
             #[cfg(not(loom))]
             #[cfg(not(target_os = "wasi"))]
+            #[cfg(not(target_os = "hermit"))]
             $item
         )*
     }


### PR DESCRIPTION
Running `cargo build` for hermit without this patch leads to several compile errors.
Using the library without this patch leads to the same errors downstream.